### PR TITLE
only use a single condition in if()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tidyRSS
 Type: Package
 Title: Tidy RSS for R
-Version: 1.2.0
+Version: 1.2.1
 Author: Robert Myles McDonnell
 Maintainer: Robert Myles McDonnell <robertmylesmcdonnell@gmail.com>
 Description:

--- a/R/tidyfeed.R
+++ b/R/tidyfeed.R
@@ -18,16 +18,16 @@
 #'   - "all": both the feed information (title, url, etc.) and the item information (title, creator, etc.) are returned.
 #'   - "feed": Only the information from the feed is returned, not the individual feed items.
 #'   - "items": opposite of the above.
-#' @examples
-
+#' @example
+#' \dontrun{
 #' # Atom feed:
 #' r_j <- tidyfeed("http://journal.r-project.org/rss.atom")
-#'
+#' }
 #' @export
-
 tidyfeed <- function(feed, result = c("all", "feed", "items")){
   invisible({
   suppressWarnings({
+  stopifnot(identical(length(feed), 1L)) # exit if more than 1 feed provided
   if(!grepl("http://", feed)){
     feed <- strsplit(feed, "://")[[1]][2]
     feed <-paste0("http://", feed)
@@ -65,9 +65,9 @@ tidyfeed <- function(feed, result = c("all", "feed", "items")){
       item_content = xml2::xml_text(xml2::xml_find_first(entries, ns = ns, "atom:content"))
     )
 
-    if(!grepl("http", res$feed_link)){
+    if(!grepl("http", unique(res$feed_link))){
       res$feed_link <- xml2::xml_text(xml2::xml_find_first(entries, ns = ns, "atom:origLink"))
-      if(!grepl("http", res$feed_link)){
+      if(!grepl("http", unique(res$feed_link))){
         res$feed_link <- xml2::xml_text(xml2::xml_find_first(entries, ns = ns, "atom:link"))
       }
     }
@@ -78,7 +78,7 @@ tidyfeed <- function(feed, result = c("all", "feed", "items")){
 
     channel <- xml2::xml_find_all(doc, "channel")
 
-    if(length(channel) == 0){
+    if(identical(length(channel), 0L)){
       ns <- xml2::xml_ns_rename(xml2::xml_ns(doc), d1 = "rss")
       channel <- xml2::xml_find_all(doc, "rss:channel", ns = ns)
       site <- xml2::xml_find_all(doc, "rss:item", ns = ns)

--- a/tests/testthat/test.feeds.R
+++ b/tests/testthat/test.feeds.R
@@ -1,4 +1,4 @@
-
+context("simple tests")
 
 test_that("tidyfeed returns an error when it should", {
  expect_error(tidyfeed("hello"))


### PR DESCRIPTION
I hit an error when trying to use this package, because I have `_R_CHECK_LENGTH_1_CONDITION_=true` set in R 3.4.0 in anticipation of the upcoming change to producing an error when `if()` is provided with a `length > 1` argument (which it really shouldn't, and currently produces a warning).

Refer: https://twitter.com/groundwalkergmb/status/842434055425556480 and https://github.com/kalibera/rifcond . 

I've made the relevant change and this now works for the example I needed. Since your `grepl` acts on a value that was repeated throughout `res`, this can be solved by making the comparison unique.

I also hit some errors trying to build/check/test, but that may be due to my recently updated system being out of whack.