### PR TITLE
some feed namespaces dont need to be renamed

### DIFF
--- a/R/rss_parse.R
+++ b/R/rss_parse.R
@@ -4,13 +4,17 @@ formats <- c("a d b Y H:M:S z", "a, d b Y H:M z",
              "a b dH:M:S Y")
 
 rss_parse <- function(doc){
-
   channel <- xml2::xml_find_all(doc, "channel")
 
   if(identical(length(channel), 0L)){
-    ns <- xml2::xml_ns_rename(xml2::xml_ns(doc), d1 = "rss")
+    if(any(names(xml2::xml_ns(doc)) == "d1")){
+      ns      <- xml2::xml_ns_rename(xml2::xml_ns(doc), d1 = "rss")
+    }else{
+      ns      <- xml2::xml_ns(doc)
+    }
+
     channel <- xml2::xml_find_all(doc, "rss:channel", ns = ns)
-    site <- xml2::xml_find_all(doc, "rss:item", ns = ns)
+    site    <- xml2::xml_find_all(doc, "rss:item", ns = ns)
 
     res <- suppressWarnings({tibble::tibble(
       feed_title = xml2::xml_text(xml2::xml_find_all(channel, "rss:title", ns = ns)),


### PR DESCRIPTION
The current setup assumes that feed namespaces need to be renamed with `xml_ns_rename`. If they don't need to renamed an error is being thrown. This PR avoids renaming if there is no _d1_ default and allows this feed to work:

```
tidyfeed("http://onlinelibrary.wiley.com/rss/journal/10.1002/(ISSN)1939-9170")
```
