### PR TITLE
Fix tidyselect `where()`warning #50

### DIFF
--- a/.github/workflows/rcheck.yaml
+++ b/.github/workflows/rcheck.yaml
@@ -26,6 +26,7 @@ jobs:
       - uses: r-lib/actions/setup-r@master
         with:
           r-version: ${{ matrix.config.r }}
+          Ncpus: 4
       - name: Install dependencies
         run: |
           install.packages(c("remotes", "rcmdcheck"))

--- a/.github/workflows/rcheck.yaml
+++ b/.github/workflows/rcheck.yaml
@@ -26,7 +26,6 @@ jobs:
       - uses: r-lib/actions/setup-r@master
         with:
           r-version: ${{ matrix.config.r }}
-          Ncpus: 4
       - name: Install dependencies
         run: |
           install.packages(c("remotes", "rcmdcheck"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tidyRSS
 Type: Package
 Title: Tidy RSS for R
-Version: 2.0.2
+Version: 2.0.3
 Author: Robert Myles McDonnell
 Maintainer: Robert Myles McDonnell <robertmylesmcdonnell@gmail.com>
 Description: 
@@ -23,11 +23,12 @@ Imports: xml2 (>= 1.3.1),
     anytime(>= 0.3.7),
     rlang (>= 0.4.6),
     glue (>= 1.4.0),
-    vctrs (>= 0.3.0)
+    vctrs (>= 0.3.0),
+    tidyselect (>= 1.1.0)
 Suggests: 
     httptest,
     knitr,
     rmarkdown,
     covr,
     testthat
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 export("%>%")
 export(tidyfeed)
+import(tidyselect)
 importFrom(anytime,anytime)
 importFrom(dplyr,across)
 importFrom(dplyr,bind_cols)

--- a/R/clean_up.R
+++ b/R/clean_up.R
@@ -1,3 +1,7 @@
+## recommended way to stop where() triggering a note in R CMD check
+## https://github.com/r-lib/tidyselect/issues/201
+if(getRversion() >= "2.15.1") utils::globalVariables("where")
+
 # takes a dataframe and feed type (JSON, Atom, RSS) as input and
 # returns a dataframe that has been 'cleaned' in the following way:
 # - columns that only have NA values are removed;
@@ -18,7 +22,7 @@ clean_up <- function(df, type, clean_tags, parse_dates) {
   # remove empty and NA cols
   df <- df %>%
     mutate(
-      across(is.character, ~ {
+      across(where(is.character), ~ {
         ifelse(nchar(.x) == 0, NA_character_, .x)
       })
     ) %>%

--- a/R/tidyfeed.R
+++ b/R/tidyfeed.R
@@ -11,6 +11,7 @@
 #' @importFrom jsonlite parse_json
 #' @importFrom glue glue
 #' @importFrom vctrs new_vctr
+#' @import tidyselect
 #' @author Robert Myles McDonnell, \email{robertmylesmcdonnell@gmail.com}
 #' @references \url{https://en.wikipedia.org/wiki/RSS}
 #' @title Extract a tidy data frame from RSS, Atom and JSON feeds

--- a/tests/testthat/test_general.R
+++ b/tests/testthat/test_general.R
@@ -85,6 +85,8 @@ test_that("df is cleaned properly", {
     names(df_cleaned),
     names(clean_up(df, "rss", clean_tags = TRUE, parse_dates = TRUE))
     )
+  ## check dplyr warning message no longer printed
+  expect_silent(clean_up(df, "rss", clean_tags = TRUE, parse_dates = TRUE))
 })
 
 test_that("dates are only parsed when they should be", {


### PR DESCRIPTION
This hopefully addresses the tidyselect `where()` warning in #50 

* Adds call to `where()`

* Imports **tidyselect** (`where()` isn't actually exported, so maybe this isn't necessary?)

* Adds unit test to check `tidyRSS::clean_up()` is silent