### PR TITLE
Fix #61

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,8 @@ Authors@R: c(
     person("Robert Myles", "McDonnell", email = "robertmylesmcdonnell@gmail.com", role = c("aut", "cre")),
     person("Jonathan", "Carroll", email = "jono@jcarroll.com.au", role = "ctb"),
     person("Mike", "Smith", email = "grimbough@gmail.com", role = "ctb"),
-    person("Joseph", "Stachelek", role = "ctb")
+    person("Joseph", "Stachelek", role = "ctb"),
+    person("Chung-hong", "Chan", email = "chainsawtiney@gmail.com", role = "ctb", comment = c(ORCID = "0000-0002-6232-7530"))
     )
 Maintainer: Robert Myles McDonnell <robertmylesmcdonnell@gmail.com>
 Description: 

--- a/R/rss_parse.R
+++ b/R/rss_parse.R
@@ -39,7 +39,7 @@ rss_parse <- function(response, list, clean_tags, parse_dates) {
     item_title = map(res_entry, "title", .default = def) %>% unlist(),
     item_link = map(res_entry, "link", .default = def) %>% unlist(),
     item_description = map(res_entry, "description", .default = def) %>%
-      unlist() %>% discard(~.x == "[ comment ]"),
+      unlist() %>% discard(safe_check_comment),
     item_pub_date = map(res_entry, "pubDate", .default = def) %>% unlist(),
     item_guid = map(res_entry, "guid", .default = def) %>% unlist(),
     item_author = map(res_entry, "author", .default = def),

--- a/R/utils.R
+++ b/R/utils.R
@@ -114,3 +114,10 @@ cleanFun <- function(htmlString) {
 }
 
 safe_join <- safely(full_join)
+
+safe_check_comment <- function(x) {
+  if (is.na(x)) {
+    return(FALSE)
+  }
+  x == "[ comment ]"
+}

--- a/tests/testthat/test_general.R
+++ b/tests/testthat/test_general.R
@@ -182,3 +182,7 @@ test_that("delist works as it should", {
     tibble(y = rep(list(c(1, "hello", TRUE)), 5))
   )
 })
+
+test_that("RSS feed without item description #61", {
+  expect_error(rss_parse("ws_catalog.rss.xml", list = FALSE, parse_dates = TRUE, clean_tags = TRUE), NA)
+})

--- a/tests/testthat/ws_catalog.rss.xml
+++ b/tests/testthat/ws_catalog.rss.xml
@@ -1,0 +1,111 @@
+<rss version="2.0">
+            <channel>
+                <title>Statistik Schweiz - Interaktive Tabellen</title>
+                <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.html</link>
+                <description>Katalog der interaktiven Tabellen vom Bundesamt für Statistik</description>
+                <language>de</language>
+                <copyright>BFS/OFS/UST/FSO</copyright>
+                <pubDate>Thu, 14 Jul 2022 08:30:00 +0200</pubDate><ttl>60</ttl>
+                <item>
+                        <title>Neue Inverkehrsetzungen von Strassenfahrzeugen nach Monaten (provisorische Daten 2022, mit Vergleich zu Vorjahren): Resultate nach Kanton, Fahrzeuggruppe, Fahrzeugart, Treibstoff, Monat und Jahr</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22926322.html</link>
+                        <pubDate>Thu, 14 Jul 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22926322</guid>
+                    </item>
+                <item>
+                        <title>Hotellerie: Angebot und Nachfrage der geöffneten Betriebe in 100 Gemeinden nach Jahr, Monat und Gemeinde</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22989079.html</link>
+                        <pubDate>Thu, 07 Jul 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22989079</guid>
+                    </item>
+                <item>
+                        <title>Hotellerie: Angebot und Nachfrage der geöffneten Betriebe nach Jahr, Monat und Kanton</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22989076.html</link>
+                        <pubDate>Thu, 07 Jul 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22989076</guid>
+                    </item>
+                <item>
+                        <title>Hotellerie: Angebot und Nachfrage der geöffneten Betriebe nach Jahr, Monat und Tourismusregion</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22989077.html</link>
+                        <pubDate>Thu, 07 Jul 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22989077</guid>
+                    </item>
+                <item>
+                        <title>Hotellerie: Ankünfte und Logiernächte der geöffneten Betriebe in 100 Gemeinden nach Jahr, Monat, Gemeinde und Gästeherkunftsland</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22989078.html</link>
+                        <pubDate>Thu, 07 Jul 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22989078</guid>
+                    </item>
+                <item>
+                        <title>Hotellerie: Ankünfte und Logiernächte der geöffneten Betriebe nach Jahr, Monat, Kanton und Gästeherkunftsland</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22989074.html</link>
+                        <pubDate>Thu, 07 Jul 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22989074</guid>
+                    </item>
+                <item>
+                        <title>Hotellerie: Ankünfte und Logiernächte der geöffneten Betriebe nach Jahr, Monat, Tourismusregion und Gästeherkunftsland</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22989075.html</link>
+                        <pubDate>Thu, 07 Jul 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22989075</guid>
+                    </item>
+                <item>
+                        <title>Materialflusskonten - Direkte Inputflüsse und wie sich diese zusammensetzen</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22869018.html</link>
+                        <pubDate>Tue, 05 Jul 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22869018</guid>
+                    </item>
+                <item>
+                        <title>Materialflusskonten - Emissionen in die Natur</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22869020.html</link>
+                        <pubDate>Tue, 05 Jul 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22869020</guid>
+                    </item>
+                <item>
+                        <title>Materialflusskonten - Indikatoren</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22869019.html</link>
+                        <pubDate>Tue, 05 Jul 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22869019</guid>
+                    </item>
+                <item>
+                        <title>Detailhandelsumsatzstatistik - monatliche Zeitreihen</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22986326.html</link>
+                        <pubDate>Thu, 30 Jun 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22986326</guid>
+                    </item>
+                <item>
+                        <title>Detailhandelsumsatzstatistik - vierteljährliche Zeitreihen</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22986330.html</link>
+                        <pubDate>Thu, 30 Jun 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22986330</guid>
+                    </item>
+                <item>
+                        <title>Umweltschutzausgaben der Unternehmen nach Wirtschaftsbranche</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22866206.html</link>
+                        <pubDate>Thu, 30 Jun 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22866206</guid>
+                    </item>
+                <item>
+                        <title>Umweltschutzausgaben der Unternehmen nach Wirtschaftsbranche und Grössenklasse</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22866210.html</link>
+                        <pubDate>Thu, 30 Jun 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22866210</guid>
+                    </item>
+                <item>
+                        <title>Abschlüsse an den Fachhochschulen (ohne PH) nach Jahr, Examensstufe, Fachbereich und Altersklasse</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22806815.html</link>
+                        <pubDate>Mon, 27 Jun 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22806815</guid>
+                    </item>
+                <item>
+                        <title>Abschlüsse an den Fachhochschulen (ohne PH) nach Jahr, Examensstufe, Fachbereich, Bildungsherkunft vor Studienbeginn und Hochschule</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22806817.html</link>
+                        <pubDate>Mon, 27 Jun 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22806817</guid>
+                    </item>
+                <item>
+                        <title>Abschlüsse an den Fachhochschulen (ohne PH) nach Jahr, Examensstufe, Fachrichtung, Geschlecht und Hochschule</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22806795.html</link>
+                        <pubDate>Mon, 27 Jun 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22806795</guid>
+                    </item>
+                <item>
+                        <title>Abschlüsse an den Fachhochschulen (ohne PH) nach Jahr, Examensstufe, Fachrichtung, Staatsangehörigkeit (Kategorie) und Hochschule</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22806813.html</link>
+                        <pubDate>Mon, 27 Jun 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22806813</guid>
+                    </item>
+                <item>
+                        <title>Abschlüsse an den Fachhochschulen (ohne PH) nach Jahr, Examensstufe, Wohnkanton vor Studienbeginn und Hochschule</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22806816.html</link>
+                        <pubDate>Mon, 27 Jun 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22806816</guid>
+                    </item>
+                <item>
+                        <title>Abschlüsse an den Fachhochschulen und pädagogischen Hochschulen nach Jahr, Examensstufe, Fachbereich und Altersklasse</title>
+                        <link>https://www.bfs.admin.ch/content/bfs/de/home/statistiken/kataloge-datenbanken/daten.assetdetail.22806853.html</link>
+                        <pubDate>Mon, 27 Jun 2022 08:30:00 +0200</pubDate><guid isPermaLink="false">bfsRSSFeed22806853</guid>
+                    </item>
+                </channel>
+        </rss>
+    


### PR DESCRIPTION
The fix of #57 makes an assumption that all items contain a
description tag. But it is not always the case and for those item
`map(res_entry, "description", .default = def)` will be `NA` (the
`def`) and the equality operator in the subsequent predicate function dies.

I've included a simple test.